### PR TITLE
fix(marker-view.coffee): on Windows, lineHeight undefined.

### DIFF
--- a/lib/marker-view.coffee
+++ b/lib/marker-view.coffee
@@ -20,9 +20,8 @@ class MarkerView
       @appendRegion(1, { row: range.end.row, column: 0 }, range.end)
 
   appendRegion: (rows, start, end) ->
-    { lineHeight, charWidth } = @editor
     css = @editor.pixelPositionForScreenPosition(start)
-    css.height = lineHeight * rows
+    css.height = atom.config.getSettings().editor.lineHeight * atom.config.getSettings().editor.fontSize * rows
     if end
       css.width = @editor.pixelPositionForScreenPosition(end).left - css.left
     else


### PR DESCRIPTION
This uses the atom.config.getSettings() in order to get lineHeight and fontSize to calculate height for css... not sure if this appropriate CoffeeScript as I am not fluent in it. Let me know!
