### PR TITLE
fix(marker-view.coffee): using @editor = atom.workspace.activePaneItem

### DIFF
--- a/lib/marker-view.coffee
+++ b/lib/marker-view.coffee
@@ -6,7 +6,7 @@ class MarkerView
   constructor: (range, parent, editor) ->
     @range = range
     @parent = parent
-    @editor = atom.workspace.activePaneItem
+    @editor = atom.workspaceView.getActiveEditor()
     @element = document.createElement('div')
     @element.className = 'marker'
     rowSpan = range.end.row - range.start.row


### PR DESCRIPTION
to grab the editor. It appears whatever I did for Windows had broken in Linux, but now it works... may need some testing on Windows/Mac, but I think this will work.
