### PR TITLE
React Editor pixelPositionForScreenPosition fix

### DIFF
--- a/lib/highlighted-area-view.coffee
+++ b/lib/highlighted-area-view.coffee
@@ -26,10 +26,6 @@ class HighlightedAreaView extends View
     @remove()
     @detach()
 
-  getEditorView: ->
-    activeView = atom.workspaceView.getActiveView()
-    if activeView instanceof EditorView then activeView else null
-
   getActiveEditor: ->
     atom.workspace.getActiveEditor()
 
@@ -62,7 +58,7 @@ class HighlightedAreaView extends View
         @ranges.push editor.markBufferRange(result.range).getScreenRange()
 
     for range in @ranges
-      view = new MarkerView(range, this, @getEditorView())
+      view = new MarkerView(range, this, @editorView)
       @append view.element
       @views.push view
 

--- a/lib/marker-view.coffee
+++ b/lib/marker-view.coffee
@@ -3,10 +3,10 @@
 module.exports =
 class MarkerView
 
-  constructor: (range, parent, editor) ->
+  constructor: (range, parent, editorView) ->
     @range = range
     @parent = parent
-    @editor = editor
+    @editorView = editorView
     @element = document.createElement('div')
     @element.className = 'marker'
     rowSpan = range.end.row - range.start.row
@@ -20,10 +20,10 @@ class MarkerView
       @appendRegion(1, { row: range.end.row, column: 0 }, range.end)
 
   appendRegion: (rows, start, end) ->
-    css = @editor.pixelPositionForScreenPosition(start)
+    css = @editorView.pixelPositionForScreenPosition(start)
     css.height = atom.config.getSettings().editor.lineHeight * atom.config.getSettings().editor.fontSize * rows
     if end
-      css.width = @editor.pixelPositionForScreenPosition(end).left - css.left
+      css.width = @editorView.pixelPositionForScreenPosition(end).left - css.left
     else
       css.right = 0
 


### PR DESCRIPTION
Use editorView instead of editor for pixelPositionForScreenPosition to fix React Editor. 

It seems like pixelPositionForScreenPosition, which is what is being used, is available to editorView which we already have. 

https://atom.io/docs/api/v0.108.0/api/classes/EditorView.html#pixelPositionForScreenPosition-instance

Tested on mac with React Editor on and Off 0.107.0
