### PR TITLE
Remove dependency on 'atom-space-pen-views'

### DIFF
--- a/lib/highlight-selected.coffee
+++ b/lib/highlight-selected.coffee
@@ -25,7 +25,6 @@ module.exports =
 
   activate: (state) ->
     @areaView = new HighlightedAreaView()
-    @areaView.attach()
 
   deactivate: ->
     @areaView?.destroy()

--- a/lib/highlighted-area-view.coffee
+++ b/lib/highlighted-area-view.coffee
@@ -1,27 +1,18 @@
 {Range, CompositeDisposable} = require 'atom'
-{View} = require 'atom-space-pen-views'
 _ = require 'underscore-plus'
 
 module.exports =
-class HighlightedAreaView extends View
-  @content: ->
-    @div class: 'highlight-selected'
+class HighlightedAreaView
 
-  initialize: ->
+  constructor: ->
     @views = []
     @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem =>
       @subscribeToActiveTextEditor()
     @subscribeToActiveTextEditor()
 
-  attach: ->
-    panel = atom.workspace.addBottomPanel(item: this)
-    panel.hide()
-
   destroy: =>
     @activeItemSubscription.dispose()
     @selectionSubscription?.dispose()
-    @remove()
-    @detach()
 
   subscribeToActiveTextEditor: ->
     @selectionSubscription?.dispose()

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "atom": ">=0.174.0 <2.0.0"
   },
   "dependencies": {
-    "underscore-plus": "1.x",
-    "atom-space-pen-views": "^2.0.3"
+    "underscore-plus": "1.x"
   },
   "devDependencies": {
     "coffee-script": "1.9.0",

--- a/spec/highlight-selected-spec.coffee
+++ b/spec/highlight-selected-spec.coffee
@@ -46,12 +46,6 @@ describe "HighlightSelected", ->
     minimapHS?.deactivate()
     minimapModule?.deactivate()
 
-  describe "when the view is loaded", ->
-    it "attaches the view", ->
-      expect(workspaceElement
-        .querySelectorAll('.highlight-selected')
-        ).toHaveLength(1)
-
   describe "when a whole word is selected", ->
     beforeEach ->
       range = new Range(new Point(8, 2), new Point(8, 8))


### PR DESCRIPTION
I noticed this package took the longest to load on my setup. It takes around 40-60ms to load according to Timecop.
With the removal of space-pen-views as a dependency this reduced the load time to ~5ms.

Is there a reason as to why this needs to be a space pen view that attaches itself as a panel to the workspace?

PS: Thanks for creating this essential package!