### PR TITLE
Added inline-block class for better compatibility

### DIFF
--- a/lib/status-bar-view.coffee
+++ b/lib/status-bar-view.coffee
@@ -2,7 +2,7 @@ module.exports =
 class StatusBarView
   constructor: ->
     @element = document.createElement 'div'
-    @element.classList.add("highlight-selected-status")
+    @element.classList.add("highlight-selected-status","inline-block")
 
   updateCount: (count) ->
     @element.textContent = "Highlighted: " + count


### PR DESCRIPTION
...with placing in status bar. Because sometimes you can have highlight status in different site of status bar ... ( for example: https://github.com/olmokramer/atom-move-status-items ) etc.