### PR TITLE
Use Syntax Theme Colors

### DIFF
--- a/styles/highlight-selected.less
+++ b/styles/highlight-selected.less
@@ -21,7 +21,7 @@
 
     // Box
     .highlight-selected .region {
-      border-color: #ddd;
+      border-color: @syntax-cursor-color;
     }
     // Background
     .highlight-selected.background .region {


### PR DESCRIPTION
I think it would be cool to use the syntax theme colors for highlighting words. I've tried it with a few themes and I think it looks a lot better when it matches the cursor color.

I don't have an opinion on what colors the background colors should be, as I never use them. However, this PR might be a good place to decide.
