### PR TITLE
Highlight selection across active panes

### DIFF
--- a/lib/highlight-selected.coffee
+++ b/lib/highlight-selected.coffee
@@ -29,6 +29,10 @@ module.exports =
       type: 'boolean'
       default: true
       description: 'Show how many matches there are'
+    highlightInPanes:
+      type: 'boolean'
+      default: true
+      description: 'Highlight selection in another panes'
 
   areaView: null
 


### PR DESCRIPTION
This feature adds highlighting across active panes.

Here's how it looks:

![screen shot 2016-06-03 at 16 39 15](https://cloud.githubusercontent.com/assets/8496729/15782219/bdba7912-29a9-11e6-88bd-40bcd26b3c2d.png)

also an option to disable this:

![screen shot 2016-06-03 at 16 42 19](https://cloud.githubusercontent.com/assets/8496729/15782352/30ef291e-29aa-11e6-84d6-cd01cba56097.png)

I suppose it does close #123 