### PR TITLE
Add HACK grammar to $ special handling

### DIFF
--- a/lib/highlighted-area-view.coffee
+++ b/lib/highlighted-area-view.coffee
@@ -114,7 +114,7 @@ class HighlightedAreaView
 
     if atom.config.get('highlight-selected.onlyHighlightWholeWords')
       if regexSearch.indexOf("\$") isnt -1 \
-      and editor.getGrammar()?.name is 'PHP'
+      and editor.getGrammar()?.name in ['PHP', 'HACK']
         regexSearch = regexSearch.replace("\$", "\$\\b")
       else
         regexSearch =  "\\b" + regexSearch


### PR DESCRIPTION
[Hack](http://hacklang.org/) is Facebook's PHP extension. It has the same `$` variable naming as PHP. The grammar's name is `HACK` https://github.com/facebook/nuclide/blob/74212773/pkg/nuclide-language-hack/grammars/hack.cson#L2.