### PR TITLE
Optimize load time

### DIFF
--- a/lib/escape-reg-exp.coffee
+++ b/lib/escape-reg-exp.coffee
@@ -1,0 +1,7 @@
+# https://github.com/atom/underscore-plus/blob/4a022cf72/src/underscore-plus.coffee#L136-L140
+
+module.exports = (string) ->
+  if string
+    string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+  else
+    ''

--- a/lib/highlighted-area-view.coffee
+++ b/lib/highlighted-area-view.coffee
@@ -1,6 +1,5 @@
 {Range, CompositeDisposable, Emitter, MarkerLayer} = require 'atom'
 StatusBarView = require './status-bar-view'
-Grim = require 'grim'
 escapeRegExp = require './escape-reg-exp'
 
 module.exports =
@@ -27,10 +26,12 @@ class HighlightedAreaView
     @statusBarTile = null
 
   onDidAddMarker: (callback) =>
+    Grim = require 'grim'
     Grim.deprecate("Please do not use. This method will be removed.")
     @emitter.on 'did-add-marker', callback
 
   onDidAddSelectedMarker: (callback) =>
+    Grim = require 'grim'
     Grim.deprecate("Please do not use. This method will be removed.")
     @emitter.on 'did-add-selected-marker', callback
 

--- a/lib/highlighted-area-view.coffee
+++ b/lib/highlighted-area-view.coffee
@@ -1,7 +1,7 @@
 {Range, CompositeDisposable, Emitter, MarkerLayer} = require 'atom'
-_ = require 'underscore-plus'
 StatusBarView = require './status-bar-view'
 Grim = require 'grim'
+escapeRegExp = require './escape-reg-exp'
 
 module.exports =
 class HighlightedAreaView
@@ -104,7 +104,7 @@ class HighlightedAreaView
 
     @selections = editor.getSelections()
 
-    text = _.escapeRegExp(@selections[0].getText())
+    text = escapeRegExp(@selections[0].getText())
     regex = new RegExp("\\S*\\w*\\b", 'gi')
     result = regex.exec(text)
 
@@ -202,10 +202,10 @@ class HighlightedAreaView
       lineRange = @getActiveEditor().bufferRangeForBufferRow(
         selectionRange.start.row)
       nonWordCharacterToTheLeft =
-        _.isEqual(selectionRange.start, lineRange.start) or
+        selectionRange.start.isEqual(lineRange.start) or
         @isNonWordCharacterToTheLeft(selection)
       nonWordCharacterToTheRight =
-        _.isEqual(selectionRange.end, lineRange.end) or
+        selectionRange.end.isEqual(lineRange.end) or
         @isNonWordCharacterToTheRight(selection)
 
       nonWordCharacterToTheLeft and nonWordCharacterToTheRight
@@ -214,7 +214,7 @@ class HighlightedAreaView
 
   isNonWordCharacter: (character) ->
     nonWordCharacters = atom.config.get('editor.nonWordCharacters')
-    new RegExp("[ \t#{_.escapeRegExp(nonWordCharacters)}]").test(character)
+    new RegExp("[ \t#{escapeRegExp(nonWordCharacters)}]").test(character)
 
   isNonWordCharacterToTheLeft: (selection) ->
     selectionStart = selection.getBufferRange().start

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "atom": ">=1.13.0 <2.0.0"
   },
   "dependencies": {
-    "underscore-plus": "1.x",
     "grim": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
* `underscore-plus` is not used for much. `_.isEqual` can be replaced with the `Point`'s own `isEqual`, and `escapeRegExp` can be copied (I'd use an npm package, but `underscore-plus`'s regex doesn't look like that from major packages out there).
* `grim` shouldn't load in the normal case, and it's easy to inline.