### PR TITLE
Allow highlighting across word boundaries

### DIFF
--- a/lib/highlighted-area-view.coffee
+++ b/lib/highlighted-area-view.coffee
@@ -107,6 +107,8 @@ class HighlightedAreaView
 
     text = @selections[0].getText()
     return if text.length < atom.config.get('highlight-selected.minimumLength')
+    regex = new RegExp("\\n")
+    return if regex.exec(text)
     regexSearch = escapeRegExp(text)
 
     regexFlags = 'g'

--- a/lib/highlighted-area-view.coffee
+++ b/lib/highlighted-area-view.coffee
@@ -105,22 +105,15 @@ class HighlightedAreaView
 
     @selections = editor.getSelections()
 
-    text = escapeRegExp(@selections[0].getText())
-    regex = new RegExp("\\S*\\w*\\b", 'gi')
-    result = regex.exec(text)
-
-    return unless result?
-    return if result[0].length < atom.config.get(
-      'highlight-selected.minimumLength') or
-              result.index isnt 0 or
-              result[0] isnt result.input
+    text = @selections[0].getText()
+    return if text.length < atom.config.get('highlight-selected.minimumLength')
+    regexSearch = escapeRegExp(text)
 
     regexFlags = 'g'
     if atom.config.get('highlight-selected.ignoreCase')
       regexFlags = 'gi'
 
     @ranges = []
-    regexSearch = result[0]
 
     if atom.config.get('highlight-selected.onlyHighlightWholeWords')
       if regexSearch.indexOf("\$") isnt -1 \


### PR DESCRIPTION
I use this package to show what will be selected when inserting multiple cursors with ctrl+d (find-and-replace:select-next). As-is, the package will fail to highlight matching strings across word boundaries even when onlyHighlightWholeWords=false. For example, consider the following lines:

    uint8_t myVar1 = 4;
    uint8_t myVar2 = 46;

From these, I might want to highlight "uint8_t myVar". The package will unexpectedly not highlight both instances. As a side note: my expected behavior is the behavior of VSCode's selection highlighter.

The changes I've made remove the regular expression which seems designed to cut off the input at word boundaries. I can't imagine any case where you would want to highlight all instances of "variable" but specifically not want to highlight all instances of "variable " when you select that extra space at the end.