### PR TITLE
Add special case for Perl `$` `%` and `@` variables

### DIFF
--- a/lib/highlighted-area-view.coffee
+++ b/lib/highlighted-area-view.coffee
@@ -124,8 +124,14 @@ class HighlightedAreaView
 
     if atom.config.get('highlight-selected.onlyHighlightWholeWords')
       if regexSearch.indexOf("\$") isnt -1 \
-      and editor.getGrammar()?.name in ['PHP', 'HACK']
+      and editor.getGrammar()?.name in ['PHP', 'HACK', 'Perl']
         regexSearch = regexSearch.replace("\$", "\$\\b")
+      else if regexSearch.indexOf("\%") isnt -1 \
+      and editor.getGrammar()?.name in ['Perl']
+          regexSearch = regexSearch.replace("\%", "\%\\b")
+      else if regexSearch.indexOf("\@") isnt -1 \
+      and editor.getGrammar()?.name in ['Perl']
+          regexSearch = regexSearch.replace("\@", "\@\\b")
       else
         regexSearch =  "\\b" + regexSearch
       regexSearch = regexSearch + "\\b"

--- a/lib/highlighted-area-view.coffee
+++ b/lib/highlighted-area-view.coffee
@@ -128,10 +128,10 @@ class HighlightedAreaView
         regexSearch = regexSearch.replace("\$", "\$\\b")
       else if regexSearch.indexOf("\%") isnt -1 \
       and editor.getGrammar()?.name in ['Perl']
-          regexSearch = regexSearch.replace("\%", "\%\\b")
+        regexSearch = regexSearch.replace("\%", "\%\\b")
       else if regexSearch.indexOf("\@") isnt -1 \
       and editor.getGrammar()?.name in ['Perl']
-          regexSearch = regexSearch.replace("\@", "\@\\b")
+        regexSearch = regexSearch.replace("\@", "\@\\b")
       else
         regexSearch =  "\\b" + regexSearch
       regexSearch = regexSearch + "\\b"


### PR DESCRIPTION
Perl uses symbols to denote variable types. Adding them to the special cases on the regex search.