### PR TITLE
Add configuration to adjust the string in the status bar

### DIFF
--- a/lib/highlight-selected.coffee
+++ b/lib/highlight-selected.coffee
@@ -33,6 +33,10 @@ module.exports =
       type: 'boolean'
       default: true
       description: 'Highlight selection in another panes'
+    statusBarString:
+      type: 'string'
+      default: 'Highlighted: %c'
+      description: 'The text to show in the status bar. %c = number of occurrences'
 
   areaView: null
 

--- a/lib/status-bar-view.coffee
+++ b/lib/status-bar-view.coffee
@@ -5,7 +5,8 @@ class StatusBarView
     @element.classList.add("highlight-selected-status","inline-block")
 
   updateCount: (count) ->
-    @element.textContent = "Highlighted: " + count
+    statusBarString = atom.config.get("highlight-selected.statusBarString")
+    @element.textContent = statusBarString.replace("%c", count)
     if count == 0
       @element.classList.add("highlight-selected-hidden")
     else


### PR DESCRIPTION
This commit adds a configuration option to adjust the string that displays in the status bar. It defaults to "Highlighted: %c" where %c is the number of occurrences found.