### PR TITLE
add command to select all markers

### DIFF
--- a/lib/highlight-selected.coffee
+++ b/lib/highlight-selected.coffee
@@ -42,6 +42,7 @@ module.exports =
 
     @subscriptions.add atom.commands.add "atom-workspace",
         'highlight-selected:toggle': => @toggle()
+        'highlight-selected:select-all': => @selectAll()
 
   deactivate: ->
     @areaView?.destroy()
@@ -61,3 +62,6 @@ module.exports =
       @areaView.enable()
     else
       @areaView.disable()
+
+  selectAll: ->
+    @areaView.selectAll()

--- a/lib/highlighted-area-view.coffee
+++ b/lib/highlighted-area-view.coffee
@@ -246,3 +246,13 @@ class HighlightedAreaView
         @setupStatusBar()
       else
         @removeStatusBar()
+
+  selectAll: =>
+    editor = @getActiveEditor()
+    markerLayers = @markerLayers
+    return unless markerLayers?.length > 0
+    ranges = []
+    for markerLayer in markerLayers
+      for marker in markerLayer.getMarkers()
+        ranges.push marker.getBufferRange()
+    editor.setSelectedBufferRanges(ranges, flash: true)


### PR DESCRIPTION
This MR adds a command to select all markers. Combined with the multi-cursor feature of Atom, this is very useful to edit all the occurrences of a world. Note that it's easier than search-and-replace since highlight-selected does not select sub-words which would match a pattern.