### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text eol=lf
+* text=auto eol=lf
 
 /spec export-ignore
 /.gitignore export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto
+
+/spec export-ignore
+/.gitignore export-ignore
+/.gitattributes export-ignore
+/.travis.yml export-ignore
+/CHANGELOG.md export-ignore
+/CONTRIBUTING.md export-ignore
+/Rakefile export-ignore
+/coffelint.json export-ignore
+/package-lock.json export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,9 @@
-* text=auto
+* text eol=lf
 
 /spec export-ignore
 /.gitignore export-ignore
 /.gitattributes export-ignore
 /.travis.yml export-ignore
-/CHANGELOG.md export-ignore
 /CONTRIBUTING.md export-ignore
 /Rakefile export-ignore
 /coffelint.json export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. Such as files used for development (docs, screenshots, tests, .travis.yml, etc).

Happy Hacktoberfest!