### PR TITLE
Use the grammar's definition of nonWordCharacters

### DIFF
--- a/spec/fixtures/sample.php
+++ b/spec/fixtures/sample.php
@@ -1,5 +1,6 @@
 <?php
   $test = "$test";
   // Some $test @test file
+  // #test
   // Don't highlight thistest, or testthis
 ?>

--- a/spec/highlight-selected-spec.coffee
+++ b/spec/highlight-selected-spec.coffee
@@ -254,13 +254,24 @@ describe "HighlightSelected", ->
         expect(editorElement.querySelectorAll(
           '.highlight-selected .region')).toHaveLength(3)
 
-    describe "being able to highlight variables when not selecting '$'", ->
+    describe "not being able to highlight variables when not selecting '$'", ->
       beforeEach ->
         atom.config.set('highlight-selected.onlyHighlightWholeWords', true)
         range = new Range(new Point(1, 3), new Point(1, 7))
         editor.setSelectedBufferRange(range)
         advanceClock(20000)
 
-      it "finds 4 regions", ->
+      it "finds 0 regions", ->
         expect(editorElement.querySelectorAll(
-          '.highlight-selected .region')).toHaveLength(4)
+          '.highlight-selected .region')).toHaveLength(0)
+
+    describe "being able to highlight other strings when not selecting '@'", ->
+      beforeEach ->
+        atom.config.set('highlight-selected.onlyHighlightWholeWords', true)
+        range = new Range(new Point(3, 6), new Point(3, 10))
+        editor.setSelectedBufferRange(range)
+        advanceClock(20000)
+
+      it "finds 0 regions", ->
+        expect(editorElement.querySelectorAll(
+          '.highlight-selected .region')).toHaveLength(2)


### PR DESCRIPTION
Unify all retrieval of the list of `nonWordCharacters` into a single function, and always pass a `TextEditor` and Point to this function, allowing it to use that point to get a `ScopeDescriptor` in order to get the list of `nonWordCharacters` specific to the language(s) at that scope.

_Note:_
The specs needed to be changed here as `language-php` **doesn't** include `$` in the list of `nonWordCharacters`, so once this is implemented if you only select `test` from `$test` it will no longer be highlighted if the whole word selection option is enabled.

```
> atom.config.get('editor.nonWordCharacters')
"/\()"':,.;<>~!@#$%^&*|+=[]{}`?-…"
atom.config.get('editor.nonWordCharacters', {scope: ['text.html.php']})
"/\()"':,.;<>~!@#%^&*|+=[]{}`?-"
```

Fixes #183.