### PR TITLE
Block only whitespace selections

### DIFF
--- a/lib/highlighted-area-view.coffee
+++ b/lib/highlighted-area-view.coffee
@@ -130,7 +130,7 @@ class HighlightedAreaView
     text = lastSelection.getText()
 
     return if text.length < atom.config.get('highlight-selected.minimumLength')
-    regex = new RegExp("\\n")
+    regex = new RegExp("^\\s+$")
     return if regex.exec(text)
 
     regexFlags = 'g'

--- a/lib/highlighted-area-view.coffee
+++ b/lib/highlighted-area-view.coffee
@@ -130,8 +130,9 @@ class HighlightedAreaView
     text = lastSelection.getText()
 
     return if text.length < atom.config.get('highlight-selected.minimumLength')
+    return if text.includes('\n')
     regex = new RegExp("^\\s+$")
-    return if regex.exec(text)
+    return if regex.test(text)
 
     regexFlags = 'g'
     if atom.config.get('highlight-selected.ignoreCase')

--- a/spec/highlight-selected-spec.coffee
+++ b/spec/highlight-selected-spec.coffee
@@ -135,13 +135,6 @@ describe "HighlightSelected", ->
       beforeEach ->
         atom.config.set('highlight-selected.onlyHighlightWholeWords', false)
 
-      it "ignores newline only selections", ->
-        range = new Range(new Point(7, 14), new Point(8, 0))
-        editor.setSelectedBufferRange(range)
-        advanceClock(20000)
-        expect(editorElement.querySelectorAll(
-          '.highlight-selected .region')).toHaveLength(0)
-
       it "ignores space only selections", ->
         range = new Range(new Point(8, 0), new Point(8, 2))
         editor.setSelectedBufferRange(range)
@@ -155,6 +148,24 @@ describe "HighlightSelected", ->
         advanceClock(20000)
         expect(editorElement.querySelectorAll(
           '.highlight-selected .region')).toHaveLength(3)
+
+    describe "ignores selections that contain a new line", ->
+      beforeEach ->
+        atom.config.set('highlight-selected.onlyHighlightWholeWords', false)
+
+      it "ignores a selection of a single newline", ->
+        range = new Range(new Point(7, 14), new Point(8, 0)) # '\n'
+        editor.setSelectedBufferRange(range)
+        advanceClock(20000)
+        expect(editorElement.querySelectorAll(
+          '.highlight-selected .region')).toHaveLength(0)
+
+      it "ignores any selection containing a newline", ->
+        range = new Range(new Point(7, 14), new Point(8, 8)) # '\n  string'
+        editor.setSelectedBufferRange(range)
+        advanceClock(20000)
+        expect(editorElement.querySelectorAll(
+          '.highlight-selected .region')).toHaveLength(0)
 
     describe "will highlight non whole words", ->
       beforeEach ->

--- a/spec/highlight-selected-spec.coffee
+++ b/spec/highlight-selected-spec.coffee
@@ -131,6 +131,31 @@ describe "HighlightSelected", ->
         expect(editorElement.querySelectorAll(
           '.highlight-selected .region')).toHaveLength(0)
 
+    describe "ignores whitespace only selections", ->
+      beforeEach ->
+        atom.config.set('highlight-selected.onlyHighlightWholeWords', false)
+
+      it "ignores newline only selections", ->
+        range = new Range(new Point(7, 14), new Point(8, 0))
+        editor.setSelectedBufferRange(range)
+        advanceClock(20000)
+        expect(editorElement.querySelectorAll(
+          '.highlight-selected .region')).toHaveLength(0)
+
+      it "ignores space only selections", ->
+        range = new Range(new Point(8, 0), new Point(8, 2))
+        editor.setSelectedBufferRange(range)
+        advanceClock(20000)
+        expect(editorElement.querySelectorAll(
+          '.highlight-selected .region')).toHaveLength(0)
+
+      it "allows selections to include whitespace", ->
+        range = new Range(new Point(8, 0), new Point(8, 8))
+        editor.setSelectedBufferRange(range)
+        advanceClock(20000)
+        expect(editorElement.querySelectorAll(
+          '.highlight-selected .region')).toHaveLength(3)
+
     describe "will highlight non whole words", ->
       beforeEach ->
         atom.config.set('highlight-selected.onlyHighlightWholeWords', false)


### PR DESCRIPTION
If the selection contains only whitespace, and no other characters, ignore it.

Fixes #182.