### PR TITLE
Support multiple highlights with ctrl-click

### DIFF
--- a/lib/search-model.js
+++ b/lib/search-model.js
@@ -76,6 +76,18 @@ module.exports = class SearchModel {
 
   constructor(selectionManager) {
     this.selectionManager = selectionManager;
+
+    atom.workspace.activePaneContainer.paneContainer.element.addEventListener("keydown", function(e) {
+      if (selectionManager.ctrlDown == false && (e.key === "Control" || e.key === "Meta")){
+        selectionManager.ctrlDown = true;
+      }
+    });
+
+    atom.workspace.activePaneContainer.paneContainer.element.addEventListener("keyup", function(e) {
+      if (selectionManager.ctrlDown == true && (e.key === "Control" || e.key === "Meta")){
+        selectionManager.ctrlDown = false;
+      }
+    });
   }
 
   handleSelection() {
@@ -84,12 +96,14 @@ module.exports = class SearchModel {
       return;
     }
 
-    this.selectionManager.removeAllMarkers();
-
     if (this.selectionManager.disabled) {
       return;
     }
     if (editor.getLastSelection().isEmpty()) {
+      if(!this.selectionManager.ctrlDown){
+        this.selectionManager.removeAllMarkers();
+      }
+
       return;
     }
 

--- a/lib/search-model.js
+++ b/lib/search-model.js
@@ -79,13 +79,13 @@ module.exports = class SearchModel {
 
     atom.workspace.activePaneContainer.paneContainer.element.addEventListener('keydown', function(e) {
       if (selectionManager.ctrlDown === false && (e.key === 'Control' || e.key === 'Meta')){
-        selectionManager.ctrlDown = true;
+        selectionManager.toggleCtrl(true);
       }
     });
 
     atom.workspace.activePaneContainer.paneContainer.element.addEventListener('keyup', function(e) {
       if (selectionManager.ctrlDown === true && (e.key === 'Control' || e.key === 'Meta')){
-        selectionManager.ctrlDown = false;
+        selectionManager.toggleCtrl(false);
       }
     });
   }

--- a/lib/search-model.js
+++ b/lib/search-model.js
@@ -77,14 +77,14 @@ module.exports = class SearchModel {
   constructor(selectionManager) {
     this.selectionManager = selectionManager;
 
-    atom.workspace.activePaneContainer.paneContainer.element.addEventListener("keydown", function(e) {
-      if (selectionManager.ctrlDown == false && (e.key === "Control" || e.key === "Meta")){
+    atom.workspace.activePaneContainer.paneContainer.element.addEventListener('keydown', function(e) {
+      if (selectionManager.ctrlDown === false && (e.key === 'Control' || e.key === 'Meta')){
         selectionManager.ctrlDown = true;
       }
     });
 
-    atom.workspace.activePaneContainer.paneContainer.element.addEventListener("keyup", function(e) {
-      if (selectionManager.ctrlDown == true && (e.key === "Control" || e.key === "Meta")){
+    atom.workspace.activePaneContainer.paneContainer.element.addEventListener('keyup', function(e) {
+      if (selectionManager.ctrlDown === true && (e.key === 'Control' || e.key === 'Meta')){
         selectionManager.ctrlDown = false;
       }
     });
@@ -100,7 +100,7 @@ module.exports = class SearchModel {
       return;
     }
     if (editor.getLastSelection().isEmpty()) {
-      if(!this.selectionManager.ctrlDown){
+      if (!this.selectionManager.ctrlDown) {
         this.selectionManager.removeAllMarkers();
       }
 

--- a/lib/selection-manager.js
+++ b/lib/selection-manager.js
@@ -13,7 +13,7 @@ module.exports = class SelectionManager {
     this.editorToMarkerLayerMap = {};
     this.markerLayers = [];
     this.resultCount = 0;
-    this.ctrlDown = false
+    this.ctrlDown = false;
 
     this.editorSubscriptions = new CompositeDisposable();
 
@@ -90,6 +90,10 @@ module.exports = class SelectionManager {
   enable() {
     this.disabled = false;
     return this.debouncedHandleSelection();
+  }
+
+  toggleCtrl(inputBool) {
+    this.ctrlDown = inputBool;
   }
 
   debouncedHandleSelection() {

--- a/lib/selection-manager.js
+++ b/lib/selection-manager.js
@@ -13,8 +13,10 @@ module.exports = class SelectionManager {
     this.editorToMarkerLayerMap = {};
     this.markerLayers = [];
     this.resultCount = 0;
+    this.ctrlDown = false
 
     this.editorSubscriptions = new CompositeDisposable();
+
     this.editorSubscriptions.add(
       atom.workspace.observeTextEditors(editor => {
         this.setupMarkerLayers(editor);


### PR DESCRIPTION
By holding ctrl (or command) down while double clicking on selections, you can have multiple text selections be highlighted.

Note how all instances of both "editor" and "selections" are highlighted below.

![image](https://user-images.githubusercontent.com/14933974/85887798-6da9d900-b7b6-11ea-8a48-b6e681ff404e.png)
